### PR TITLE
Avoid passing `--email` flag

### DIFF
--- a/commands/login.js
+++ b/commands/login.js
@@ -33,7 +33,6 @@ function dockerLogin(registry, password, verbose) {
   return new Promise((resolve, reject) => {
     let args = [
       'login',
-      '--email=_',
       '--username=_',
       `--password=${ password }`,
       registry


### PR DESCRIPTION
Whenever you run the `login` command, you see this:

```
Flag --email has been deprecated, will be removed in 1.13.
```

I think it's safe to assume that most users will be on a recent version so we should get this in and prevent breakage.
