### PR TITLE
Remove unnecessary uuid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "is-there": "4.0.0",
     "lodash": "3.3.1",
     "mkdirp": "^0.5.0",
-    "node-uuid": "^1.4.3",
     "progress": "1.1.8",
     "request": "2.53.0",
     "superagent": "^0.21.0",


### PR DESCRIPTION
The dependency was introduced in 3571eccc7d6920ab3e173c9314ad2ea924e5ad3e, but `lib/docker.js` was removed in 340955cc3622939b3ca2809e6f0656e69d380d46.

I'm not finding any occurence of `uuid` in the project, and it does appear to keep working with it removed.

cc @hunterloftis 