### PR TITLE
Passes password to 'docker login' via stdin

### DIFF
--- a/commands/login.js
+++ b/commands/login.js
@@ -35,9 +35,10 @@ function dockerLogin (registry, password, verbose) {
   let args = [
     'login',
     '--username=_',
-    `--password=${ password }`,
+    '--password-stdin',
     registry
   ]
+
   log(verbose, args)
-  return Sanbashi.cmd('docker', args)
+  return Sanbashi.cmd('docker', args, {input: password})
 }

--- a/lib/sanbashi.js
+++ b/lib/sanbashi.js
@@ -101,10 +101,19 @@ Sanbashi.pushImage = function (resource, verbose) {
   return Sanbashi.cmd('docker', args)
 }
 
-Sanbashi.cmd = function (cmd, args) {
+Sanbashi.cmd = function (cmd, args, options = {}) {
+  let stdio = [process.stdin, process.stdout, process.stderr]
+  if (options.input) {
+    stdio[0] = 'pipe'
+  }
+
   return new Promise((resolve, reject) => {
-    Child.spawn(cmd, args, {stdio: 'inherit'})
-      .on('exit', (code, signal) => {
+    let child = Child.spawn(cmd, args, {stdio: stdio})
+
+    if (child.stdin) {
+      child.stdin.end(options.input)
+    }
+    child.on('exit', (code, signal) => {
         if (signal || code) reject(signal || code)
         else resolve()
       })


### PR DESCRIPTION
Currently `heroku container:login` prints a warning:

```
$ heroku container:login
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Login Succeeded
```

Since Docker 17.07, `docker login` has [supported the --password-stdin flag](https://github.com/docker/cli/pull/271) and prints a warning if `--password` is used. Is it OK to assume docker clients are at least that new, or does this plugin need to support older versions?