### PR TITLE
Rename default process type from standard to web

### DIFF
--- a/commands/push.js
+++ b/commands/push.js
@@ -55,14 +55,11 @@ let push = async function (context, heroku) {
 
   let possibleJobs = Sanbashi.getJobs(`${ registry }/${ context.app }`, dockerfiles, context.args[0])
   let jobs = []
-  if (recurse) {
-    if (context.args.length) {
-      possibleJobs = Sanbashi.filterByProcessType(possibleJobs, context.args)
-    }
-    jobs = await Sanbashi.chooseJobs(possibleJobs)
-  } else if (possibleJobs.web) {
-    jobs = possibleJobs.web || []
+
+  if (context.args.length) {
+    possibleJobs = Sanbashi.filterByProcessType(possibleJobs, context.args)
   }
+  jobs = await Sanbashi.chooseJobs(possibleJobs, recurse)
   if (!jobs.length) {
     cli.warn('No images to push')
     process.exit(1)

--- a/commands/push.js
+++ b/commands/push.js
@@ -53,7 +53,7 @@ let push = async function (context, heroku) {
   let registry = `registry.${ herokuHost }`
   let dockerfiles = Sanbashi.getDockerfiles(process.cwd(), recurse)
 
-  let possibleJobs = Sanbashi.getJobs(`${ registry }/${ context.app }`, dockerfiles)
+  let possibleJobs = Sanbashi.getJobs(`${ registry }/${ context.app }`, dockerfiles, context.args[0])
   let jobs = []
   if (recurse) {
     if (context.args.length) {
@@ -61,7 +61,6 @@ let push = async function (context, heroku) {
     }
     jobs = await Sanbashi.chooseJobs(possibleJobs)
   } else if (possibleJobs.web) {
-    possibleJobs.web.forEach((pj) => { pj.resource = pj.resource.replace(/web$/, context.args[0])})
     jobs = possibleJobs.web || []
   }
   if (!jobs.length) {

--- a/commands/push.js
+++ b/commands/push.js
@@ -60,9 +60,9 @@ let push = async function (context, heroku) {
       possibleJobs = Sanbashi.filterByProcessType(possibleJobs, context.args)
     }
     jobs = await Sanbashi.chooseJobs(possibleJobs)
-  } else if (possibleJobs.standard) {
-    possibleJobs.standard.forEach((pj) => { pj.resource = pj.resource.replace(/standard$/, context.args[0])})
-    jobs = possibleJobs.standard || []
+  } else if (possibleJobs.web) {
+    possibleJobs.web.forEach((pj) => { pj.resource = pj.resource.replace(/web$/, context.args[0])})
+    jobs = possibleJobs.web || []
   }
   if (!jobs.length) {
     cli.warn('No images to push')
@@ -74,7 +74,7 @@ let push = async function (context, heroku) {
 
   try {
     for (let job of jobs) {
-      if (job.name === 'standard') {
+      if (job.default) {
         cli.styledHeader(`Building ${context.args} (${job.dockerfile })`)
       } else {
         cli.styledHeader(`Building ${job.name} (${job.dockerfile})`)
@@ -90,7 +90,7 @@ let push = async function (context, heroku) {
 
   try {
     for (let job of jobs) {
-      if (job.name === 'standard') {
+      if (job.default) {
         cli.styledHeader(`Pushing ${context.args} (${job.dockerfile })`)
       } else {
         cli.styledHeader(`Pushing ${job.name} (${job.dockerfile })`)

--- a/commands/run.js
+++ b/commands/run.js
@@ -45,12 +45,8 @@ let run = async function (context, heroku) {
   let registry = `registry.${ herokuHost }`
   let dockerfiles = Sanbashi.getDockerfiles(process.cwd(), false)
   let possibleJobs = Sanbashi.getJobs(`${ registry }/${ context.app }`, dockerfiles)
+  let jobs = await Sanbashi.chooseJobs(possibleJobs, false)
 
-  let jobs = []
-  if (possibleJobs.standard) {
-    possibleJobs.standard.forEach((pj) => { pj.resource = pj.resource.replace(/standard$/, processType)})
-    jobs = possibleJobs.standard || []
-  }
   if (!jobs.length) {
     cli.warn('No images to run')
     process.exit(1)

--- a/lib/sanbashi.js
+++ b/lib/sanbashi.js
@@ -25,17 +25,19 @@ Sanbashi.getDockerfiles = function (rootdir, recursive) {
   return dockerfiles.map(file => Path.join(rootdir, file))
 }
 
-Sanbashi.getJobs = function (resourceRoot, dockerfiles) {
+Sanbashi.getJobs = function (resourceRoot, dockerfiles, processType) {
   return dockerfiles
   // convert all Dockerfiles into job Objects
     .map((dockerfile) => {
       let match = dockerfile.match(DOCKERFILE_REGEX)
       if (!match) return
       let proc = (match[1] || '.web').slice(1)
+      let isDefault = match[1] == undefined
+
       return {
         name: proc,
-        default: match[1] == undefined,
-        resource: `${ resourceRoot }/${ proc }`,
+        default: isDefault,
+        resource: `${ resourceRoot }/${ isDefault ? processType : proc }`,
         dockerfile: dockerfile,
         postfix: Path.basename(dockerfile) === 'Dockerfile' ? 0 : 1,
         depth: Path.normalize(dockerfile).split(Path.sep).length

--- a/lib/sanbashi.js
+++ b/lib/sanbashi.js
@@ -31,9 +31,10 @@ Sanbashi.getJobs = function (resourceRoot, dockerfiles) {
     .map((dockerfile) => {
       let match = dockerfile.match(DOCKERFILE_REGEX)
       if (!match) return
-      let proc = (match[1] || '.standard').slice(1)
+      let proc = (match[1] || '.web').slice(1)
       return {
         name: proc,
+        default: match[1] == undefined,
         resource: `${ resourceRoot }/${ proc }`,
         dockerfile: dockerfile,
         postfix: Path.basename(dockerfile) === 'Dockerfile' ? 0 : 1,

--- a/lib/sanbashi.js
+++ b/lib/sanbashi.js
@@ -55,9 +55,13 @@ Sanbashi.getJobs = function (resourceRoot, dockerfiles, processType) {
     }, {})
 }
 
-Sanbashi.chooseJobs = async function (jobs) {
+Sanbashi.chooseJobs = async function (jobs, recurse) {
   let chosenJobs = []
   for (let processType in jobs) {
+    if (!recurse && processType != 'web') {
+      continue
+    }
+
     let group = jobs[processType]
     if (group.length > 1) {
       let prompt = {

--- a/test/sanbashi.test.js
+++ b/test/sanbashi.test.js
@@ -56,9 +56,9 @@ describe('Sanbashi', () => {
       ]
       const resourceRoot = 'rootfulroot'
       const results = Sanbashi.getJobs(resourceRoot, dockerfiles)
-      expect(results.web).to.have.property('length', 1)
+      expect(results.web).to.have.property('length', 2)
       expect(results.web[0]).to.have.property('dockerfile', 'Dockerfile.web')
-      expect(results.standard[0]).to.have.property('dockerfile', 'Nested/Dockerfile')
+      expect(results.web[1]).to.have.property('dockerfile', 'Nested/Dockerfile')
       expect(results.worker[0]).to.have.property('dockerfile', 'Nested/Dockerfile.worker')
     })
     it('groups the jobs by process type', () => {
@@ -69,10 +69,9 @@ describe('Sanbashi', () => {
       ]
       const resourceRoot = 'rootfulroot'
       const results = Sanbashi.getJobs(resourceRoot, dockerfiles)
-      expect(results).to.have.keys('worker', 'web', 'standard')
+      expect(results).to.have.keys('worker', 'web')
       expect(results['worker'].map(j => j.dockerfile)).to.have.members([Path.join('.', 'Nested', 'Dockerfile.worker')])
-      expect(results['web'].map(j => j.dockerfile)).to.have.members([Path.join('.', 'Dockerfile.web')])
-      expect(results['standard'].map(j => j.dockerfile)).to.have.members([Path.join('.', 'Nested', 'Dockerfile')])
+      expect(results['web'].map(j => j.dockerfile)).to.have.members([Path.join('.', 'Dockerfile.web'), Path.join('.', 'Nested', 'Dockerfile')])
     })
   })
   describe('.chooseJobs', () => {

--- a/test/sanbashi.test.js
+++ b/test/sanbashi.test.js
@@ -75,13 +75,31 @@ describe('Sanbashi', () => {
     })
   })
   describe('.chooseJobs', () => {
+    it('returns all entries recursively', async () => {
+      const dockerfiles = [Path.join('.', 'Nested', 'Dockerfile.web'), Path.join('.', 'Nested', 'Dockerfile.worker')]
+      const jobs = Sanbashi.getJobs('rootfulroot', dockerfiles)
+      let chosenJob = await Sanbashi.chooseJobs(jobs, true)
+      expect(chosenJob[0]).to.have.property('dockerfile', dockerfiles[0])
+      expect(chosenJob[1]).to.have.property('dockerfile', dockerfiles[1])
+      expect(chosenJob).to.have.property('length', 2)
+    })
+
     it('returns the entry when only one exists', async () => {
       const dockerfiles = [Path.join('.', 'Nested', 'Dockerfile.web')]
       const jobs = Sanbashi.getJobs('rootfulroot', dockerfiles)
-      let chosenJob = await Sanbashi.chooseJobs(jobs)
+      let chosenJob = await Sanbashi.chooseJobs(jobs, true)
       expect(chosenJob[0]).to.have.property('dockerfile', dockerfiles[0])
       expect(chosenJob).to.have.property('length', 1)
     })
+
+    it('does not fetch the data recursively', async () => {
+      const dockerfiles = [Path.join('.', 'Nested', 'Dockerfile.web'), Path.join('.', 'Nested', 'Dockerfile.worker')]
+      const jobs = Sanbashi.getJobs('rootfulroot', dockerfiles)
+      let chosenJob = await Sanbashi.chooseJobs(jobs, false)
+      expect(chosenJob[0]).to.have.property('dockerfile', dockerfiles[0])
+      expect(chosenJob).to.have.property('length', 1)
+    })
+
     afterEach(() => {
       if (Inquirer.prompt.restore)
         Inquirer.prompt.restore()


### PR DESCRIPTION
This changes the behavior slightly, as there can be a `Dockerfile` and `Dockerfile.web`.
But it also prevents unexpected issues if someone has a `Dockerfile.standard`.