### PR TITLE
Use the Docker version to negotiate how to pass passwords.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,8 @@
 machine:
   node:
     version: v8.5.0
+  services:
+    - docker
 test:
   override:
     - npm test

--- a/commands/login.js
+++ b/commands/login.js
@@ -31,7 +31,16 @@ async function login (context, heroku) {
   }
 }
 
-function dockerLogin (registry, password, verbose) {
+async function dockerLogin (registry, password, verbose) {
+  let [major, minor] = await Sanbashi.version()
+
+  if (major > 17 || major == 17 && minor >= 1) {
+    return await dockerLoginStdin(registry, password, verbose)
+  }
+  return await dockerLoginArgv(registry, password, verbose)
+}
+
+function dockerLoginStdin(registry, password, verbose) {
   let args = [
     'login',
     '--username=_',
@@ -41,4 +50,16 @@ function dockerLogin (registry, password, verbose) {
 
   log(verbose, args)
   return Sanbashi.cmd('docker', args, {input: password})
+}
+
+function dockerLoginArgv(registry, password, verbose) {
+  let args = [
+    'login',
+    '--username=_',
+    `--password=${password}`,
+    registry
+  ]
+
+  log(verbose, args)
+  return Sanbashi.cmd('docker', args)
 }

--- a/test/sanbashi.test.js
+++ b/test/sanbashi.test.js
@@ -130,4 +130,12 @@ describe('Sanbashi', () => {
       Sanbashi.cmd.restore() // Unwraps the spy
     });
   })
+  describe('.version', () => {
+    it('returns a major and a minor component', async () => {
+      let version = await Sanbashi.version()
+      expect(version).to.have.property('length', 2)
+      expect(version[0]).to.not.be.an('undefined')
+      expect(version[1]).to.not.be.an('undefined')
+    })
+  })
 })


### PR DESCRIPTION
This follows up on #27, and should reinstate support for older versions of Docker.