### PR TITLE
Fix the `container:push [not ‘web’]` use-case.

### DIFF
--- a/commands/push.js
+++ b/commands/push.js
@@ -4,6 +4,7 @@ const Sanbashi = require('../lib/sanbashi')
 let usage = `
     ${ cli.color.bold.underline.magenta('Usage:')}
     ${ cli.color.cmd('heroku container:push web')}                          # Pushes Dockerfile to web process type
+    ${ cli.color.cmd('heroku container:push worker')}                       # Pushes Dockerfile to worker process type
     ${ cli.color.cmd('heroku container:push web worker --recursive')}       # Pushes Dockerfile.web and Dockerfile.worker
     ${ cli.color.cmd('heroku container:push --recursive')}                  # Pushes Dockerfile.*
     ${ cli.color.cmd('heroku container:push web --arg ENV=live,HTTPS=on')}  # Build-time variables`
@@ -59,7 +60,7 @@ let push = async function (context, heroku) {
   if (context.args.length) {
     possibleJobs = Sanbashi.filterByProcessType(possibleJobs, context.args)
   }
-  jobs = await Sanbashi.chooseJobs(possibleJobs, recurse)
+  jobs = await Sanbashi.chooseJobs(possibleJobs, recurse ? false : context.args[0])
   if (!jobs.length) {
     cli.warn('No images to push')
     process.exit(1)

--- a/commands/run.js
+++ b/commands/run.js
@@ -45,7 +45,7 @@ let run = async function (context, heroku) {
   let registry = `registry.${ herokuHost }`
   let dockerfiles = Sanbashi.getDockerfiles(process.cwd(), false)
   let possibleJobs = Sanbashi.getJobs(`${ registry }/${ context.app }`, dockerfiles)
-  let jobs = await Sanbashi.chooseJobs(possibleJobs, false)
+  let jobs = await Sanbashi.chooseJobs(possibleJobs)
 
   if (!jobs.length) {
     cli.warn('No images to run')

--- a/lib/sanbashi.js
+++ b/lib/sanbashi.js
@@ -7,7 +7,7 @@ let os = require("os")
 const Child = require('child_process')
 const log = require('./log')
 
-const DOCKERFILE_REGEX = /\bDockerfile(.\w*)?$/
+const DOCKERFILE_REGEX = /\bDockerfile\.?(\w*)?$/
 let Sanbashi = function () {}
 
 Sanbashi.getDockerfiles = function (rootdir, recursive) {
@@ -31,7 +31,7 @@ Sanbashi.getJobs = function (resourceRoot, dockerfiles, processType) {
     .map((dockerfile) => {
       let match = dockerfile.match(DOCKERFILE_REGEX)
       if (!match) return
-      let proc = (match[1] || '.web').slice(1)
+      let proc = match[1] || processType || 'web'
       let isDefault = match[1] == undefined
 
       return {
@@ -55,10 +55,10 @@ Sanbashi.getJobs = function (resourceRoot, dockerfiles, processType) {
     }, {})
 }
 
-Sanbashi.chooseJobs = async function (jobs, recurse) {
+Sanbashi.chooseJobs = async function (jobs, restrictedToType) {
   let chosenJobs = []
   for (let processType in jobs) {
-    if (!recurse && processType != 'web') {
+    if (restrictedToType && processType != restrictedToType) {
       continue
     }
 

--- a/test/sanbashi.test.js
+++ b/test/sanbashi.test.js
@@ -61,6 +61,24 @@ describe('Sanbashi', () => {
       expect(results.web[1]).to.have.property('dockerfile', 'Nested/Dockerfile.web')
       expect(results.worker[0]).to.have.property('dockerfile', 'Nested/Dockerfile.worker')
     })
+    it('uses given process type', () => {
+      const dockerfiles = [
+        Path.join('.', 'Nested', 'Dockerfile')
+      ]
+      const resourceRoot = 'rootfulroot'
+      const results = Sanbashi.getJobs(resourceRoot, dockerfiles, 'worker')
+      expect(results.worker).to.have.property('length', 1)
+      expect(results.worker[0]).to.have.property('dockerfile', 'Nested/Dockerfile')
+    })
+    it('fallbacks to the "web" process type', () => {
+      const dockerfiles = [
+        Path.join('.', 'Nested', 'Dockerfile')
+      ]
+      const resourceRoot = 'rootfulroot'
+      const results = Sanbashi.getJobs(resourceRoot, dockerfiles)
+      expect(results.web).to.have.property('length', 1)
+      expect(results.web[0]).to.have.property('dockerfile', 'Nested/Dockerfile')
+    })
     it('groups the jobs by process type', () => {
       const dockerfiles = [
         Path.join('.', 'Nested', 'Dockerfile.worker'),
@@ -78,7 +96,7 @@ describe('Sanbashi', () => {
     it('returns all entries recursively', async () => {
       const dockerfiles = [Path.join('.', 'Nested', 'Dockerfile.web'), Path.join('.', 'Nested', 'Dockerfile.worker')]
       const jobs = Sanbashi.getJobs('rootfulroot', dockerfiles)
-      let chosenJob = await Sanbashi.chooseJobs(jobs, true)
+      let chosenJob = await Sanbashi.chooseJobs(jobs)
       expect(chosenJob[0]).to.have.property('dockerfile', dockerfiles[0])
       expect(chosenJob[1]).to.have.property('dockerfile', dockerfiles[1])
       expect(chosenJob).to.have.property('length', 2)
@@ -87,15 +105,15 @@ describe('Sanbashi', () => {
     it('returns the entry when only one exists', async () => {
       const dockerfiles = [Path.join('.', 'Nested', 'Dockerfile.web')]
       const jobs = Sanbashi.getJobs('rootfulroot', dockerfiles)
-      let chosenJob = await Sanbashi.chooseJobs(jobs, true)
+      let chosenJob = await Sanbashi.chooseJobs(jobs)
       expect(chosenJob[0]).to.have.property('dockerfile', dockerfiles[0])
       expect(chosenJob).to.have.property('length', 1)
     })
 
-    it('does not fetch the data recursively', async () => {
+    it('returns only entries of given type', async () => {
       const dockerfiles = [Path.join('.', 'Nested', 'Dockerfile.web'), Path.join('.', 'Nested', 'Dockerfile.worker')]
       const jobs = Sanbashi.getJobs('rootfulroot', dockerfiles)
-      let chosenJob = await Sanbashi.chooseJobs(jobs, false)
+      let chosenJob = await Sanbashi.chooseJobs(jobs, 'web')
       expect(chosenJob[0]).to.have.property('dockerfile', dockerfiles[0])
       expect(chosenJob).to.have.property('length', 1)
     })

--- a/test/sanbashi.test.js
+++ b/test/sanbashi.test.js
@@ -52,26 +52,26 @@ describe('Sanbashi', () => {
       const dockerfiles = [
         Path.join('.', 'Nested', 'Dockerfile.worker'),
         Path.join('.', 'Dockerfile.web'),
-        Path.join('.', 'Nested', 'Dockerfile')
+        Path.join('.', 'Nested', 'Dockerfile.web')
       ]
       const resourceRoot = 'rootfulroot'
       const results = Sanbashi.getJobs(resourceRoot, dockerfiles)
       expect(results.web).to.have.property('length', 2)
       expect(results.web[0]).to.have.property('dockerfile', 'Dockerfile.web')
-      expect(results.web[1]).to.have.property('dockerfile', 'Nested/Dockerfile')
+      expect(results.web[1]).to.have.property('dockerfile', 'Nested/Dockerfile.web')
       expect(results.worker[0]).to.have.property('dockerfile', 'Nested/Dockerfile.worker')
     })
     it('groups the jobs by process type', () => {
       const dockerfiles = [
         Path.join('.', 'Nested', 'Dockerfile.worker'),
         Path.join('.', 'Dockerfile.web'),
-        Path.join('.', 'Nested', 'Dockerfile')
+        Path.join('.', 'Nested', 'Dockerfile.web'),
       ]
       const resourceRoot = 'rootfulroot'
       const results = Sanbashi.getJobs(resourceRoot, dockerfiles)
       expect(results).to.have.keys('worker', 'web')
       expect(results['worker'].map(j => j.dockerfile)).to.have.members([Path.join('.', 'Nested', 'Dockerfile.worker')])
-      expect(results['web'].map(j => j.dockerfile)).to.have.members([Path.join('.', 'Dockerfile.web'), Path.join('.', 'Nested', 'Dockerfile')])
+      expect(results['web'].map(j => j.dockerfile)).to.have.members([Path.join('.', 'Dockerfile.web'), Path.join('.', 'Nested', 'Dockerfile.web')])
     })
   })
   describe('.chooseJobs', () => {


### PR DESCRIPTION
This regression was introduced in #30.

Before that PR it was possible to deploy non-web-type images, e.g. `heroku container:push worker`. After it, running such command resulted only in "No images to push" output.

This PR restores that deployment functionality.