### PR TITLE
Fix pushing a non-web Dockerfile non-recursively

### DIFF
--- a/commands/push.js
+++ b/commands/push.js
@@ -51,7 +51,7 @@ let push = async function (context, heroku) {
   }
   let herokuHost = process.env.HEROKU_HOST || 'heroku.com'
   let registry = `registry.${ herokuHost }`
-  let dockerfiles = Sanbashi.getDockerfiles(process.cwd(), recurse)
+  let dockerfiles = Sanbashi.getDockerfiles(process.cwd())
 
   let possibleJobs = Sanbashi.getJobs(`${ registry }/${ context.app }`, dockerfiles, context.args[0])
   let jobs = []

--- a/commands/run.js
+++ b/commands/run.js
@@ -43,7 +43,7 @@ let run = async function (context, heroku) {
 
   let herokuHost = process.env.HEROKU_HOST || 'heroku.com'
   let registry = `registry.${ herokuHost }`
-  let dockerfiles = Sanbashi.getDockerfiles(process.cwd(), false)
+  let dockerfiles = Sanbashi.getDockerfiles(process.cwd())
   let possibleJobs = Sanbashi.getJobs(`${ registry }/${ context.app }`, dockerfiles)
   let jobs = await Sanbashi.chooseJobs(possibleJobs, false)
 

--- a/lib/sanbashi.js
+++ b/lib/sanbashi.js
@@ -10,19 +10,15 @@ const log = require('./log')
 const DOCKERFILE_REGEX = /\bDockerfile(.\w*)?$/
 let Sanbashi = function () {}
 
-Sanbashi.getDockerfiles = function (rootdir, recursive) {
-  let match = recursive ? './**/Dockerfile?(.)*' : 'Dockerfile*'
-  let dockerfiles = Glob.sync(match, {
+Sanbashi.getDockerfiles = function (rootdir) {
+  let dockerfiles = Glob.sync('./**/Dockerfile?(.)*', {
     cwd: rootdir,
     nonull: false,
     nodir: true
   })
-  if (recursive) {
-    dockerfiles = dockerfiles.filter(df => df.match(/Dockerfile\.[\w]+/))
-  } else {
-    dockerfiles = dockerfiles.filter(df => df.match(/Dockerfile$/))
-  }
-  return dockerfiles.map(file => Path.join(rootdir, file))
+  return dockerfiles.
+    filter(df => df.match(/Dockerfile\.[\w]+/)).
+    map(file => Path.join(rootdir, file))
 }
 
 Sanbashi.getJobs = function (resourceRoot, dockerfiles, processType) {
@@ -58,7 +54,7 @@ Sanbashi.getJobs = function (resourceRoot, dockerfiles, processType) {
 Sanbashi.chooseJobs = async function (jobs, recurse) {
   let chosenJobs = []
   for (let processType in jobs) {
-    if (!recurse && processType != 'web') {
+    if (!recurse && chosenJobs.length > 0) {
       continue
     }
 

--- a/test/sanbashi.test.js
+++ b/test/sanbashi.test.js
@@ -8,18 +8,13 @@ describe('Sanbashi', () => {
   describe('.getDockerfiles', () => {
     it('can recurse the directory', () => {
       const searchpath = Path.join(process.cwd(), './test/fixtures')
-      let results = Sanbashi.getDockerfiles(searchpath, true)
+      let results = Sanbashi.getDockerfiles(searchpath)
       expect(results).to.have.members([`${searchpath}/Dockerfile.web`, `${searchpath}/Nested/Dockerfile.web`])
     })
-    it('when recursing, rejects dockerfiles that have no postfix in the name', () => {
+    it('rejects dockerfiles that have no postfix in the name', () => {
       const searchpath = Path.join(process.cwd(), './test/fixtures')
-      let results = Sanbashi.getDockerfiles(searchpath, true)
+      let results = Sanbashi.getDockerfiles(searchpath)
       expect(results).to.not.have.members([`${searchpath}/Dockerfile`])
-    })
-    it('returns only regular Dockerfiles when not recursing', () => {
-      const searchpath = Path.join(process.cwd(), './test/fixtures/Nested')
-      let results = Sanbashi.getDockerfiles(searchpath, false)
-      expect(results).to.have.members([`${searchpath}/Dockerfile`])
     })
   })
   describe('.filterByProcessType', () => {
@@ -97,6 +92,16 @@ describe('Sanbashi', () => {
       const jobs = Sanbashi.getJobs('rootfulroot', dockerfiles)
       let chosenJob = await Sanbashi.chooseJobs(jobs, false)
       expect(chosenJob[0]).to.have.property('dockerfile', dockerfiles[0])
+      expect(chosenJob[0].name).to.equal('web')
+      expect(chosenJob).to.have.property('length', 1)
+    })
+
+    it('fetches a non-web process non-recursively', async () => {
+      const dockerfiles = [Path.join('.', 'Nested', 'Dockerfile.worker')]
+      const jobs = Sanbashi.getJobs('rootfulroot', dockerfiles)
+      let chosenJob = await Sanbashi.chooseJobs(jobs, false)
+      expect(chosenJob[0]).to.have.property('dockerfile', dockerfiles[0])
+      expect(chosenJob[0].name).to.equal('worker')
       expect(chosenJob).to.have.property('length', 1)
     })
 


### PR DESCRIPTION
#30 broke pushing a single Dockerfile non-recursively when it's not web.

This is another approach to fixing #35. When fetching Dockerfiles, we always pick everything.
It's only when choosing the ones to push that we filter based on recursivity.