### PR TITLE
Revert "Rename default process type from standard to web"

### DIFF
--- a/commands/run.js
+++ b/commands/run.js
@@ -45,8 +45,12 @@ let run = async function (context, heroku) {
   let registry = `registry.${ herokuHost }`
   let dockerfiles = Sanbashi.getDockerfiles(process.cwd(), false)
   let possibleJobs = Sanbashi.getJobs(`${ registry }/${ context.app }`, dockerfiles)
-  let jobs = await Sanbashi.chooseJobs(possibleJobs, false)
 
+  let jobs = []
+  if (possibleJobs.standard) {
+    possibleJobs.standard.forEach((pj) => { pj.resource = pj.resource.replace(/standard$/, processType)})
+    jobs = possibleJobs.standard || []
+  }
   if (!jobs.length) {
     cli.warn('No images to run')
     process.exit(1)

--- a/lib/sanbashi.js
+++ b/lib/sanbashi.js
@@ -25,19 +25,16 @@ Sanbashi.getDockerfiles = function (rootdir, recursive) {
   return dockerfiles.map(file => Path.join(rootdir, file))
 }
 
-Sanbashi.getJobs = function (resourceRoot, dockerfiles, processType) {
+Sanbashi.getJobs = function (resourceRoot, dockerfiles) {
   return dockerfiles
   // convert all Dockerfiles into job Objects
     .map((dockerfile) => {
       let match = dockerfile.match(DOCKERFILE_REGEX)
       if (!match) return
-      let proc = (match[1] || '.web').slice(1)
-      let isDefault = match[1] == undefined
-
+      let proc = (match[1] || '.standard').slice(1)
       return {
         name: proc,
-        default: isDefault,
-        resource: `${ resourceRoot }/${ isDefault ? processType : proc }`,
+        resource: `${ resourceRoot }/${ proc }`,
         dockerfile: dockerfile,
         postfix: Path.basename(dockerfile) === 'Dockerfile' ? 0 : 1,
         depth: Path.normalize(dockerfile).split(Path.sep).length
@@ -55,13 +52,9 @@ Sanbashi.getJobs = function (resourceRoot, dockerfiles, processType) {
     }, {})
 }
 
-Sanbashi.chooseJobs = async function (jobs, recurse) {
+Sanbashi.chooseJobs = async function (jobs) {
   let chosenJobs = []
   for (let processType in jobs) {
-    if (!recurse && processType != 'web') {
-      continue
-    }
-
     let group = jobs[processType]
     if (group.length > 1) {
       let prompt = {

--- a/test/sanbashi.test.js
+++ b/test/sanbashi.test.js
@@ -56,9 +56,9 @@ describe('Sanbashi', () => {
       ]
       const resourceRoot = 'rootfulroot'
       const results = Sanbashi.getJobs(resourceRoot, dockerfiles)
-      expect(results.web).to.have.property('length', 2)
+      expect(results.web).to.have.property('length', 1)
       expect(results.web[0]).to.have.property('dockerfile', 'Dockerfile.web')
-      expect(results.web[1]).to.have.property('dockerfile', 'Nested/Dockerfile')
+      expect(results.standard[0]).to.have.property('dockerfile', 'Nested/Dockerfile')
       expect(results.worker[0]).to.have.property('dockerfile', 'Nested/Dockerfile.worker')
     })
     it('groups the jobs by process type', () => {
@@ -69,37 +69,20 @@ describe('Sanbashi', () => {
       ]
       const resourceRoot = 'rootfulroot'
       const results = Sanbashi.getJobs(resourceRoot, dockerfiles)
-      expect(results).to.have.keys('worker', 'web')
+      expect(results).to.have.keys('worker', 'web', 'standard')
       expect(results['worker'].map(j => j.dockerfile)).to.have.members([Path.join('.', 'Nested', 'Dockerfile.worker')])
-      expect(results['web'].map(j => j.dockerfile)).to.have.members([Path.join('.', 'Dockerfile.web'), Path.join('.', 'Nested', 'Dockerfile')])
+      expect(results['web'].map(j => j.dockerfile)).to.have.members([Path.join('.', 'Dockerfile.web')])
+      expect(results['standard'].map(j => j.dockerfile)).to.have.members([Path.join('.', 'Nested', 'Dockerfile')])
     })
   })
   describe('.chooseJobs', () => {
-    it('returns all entries recursively', async () => {
-      const dockerfiles = [Path.join('.', 'Nested', 'Dockerfile.web'), Path.join('.', 'Nested', 'Dockerfile.worker')]
-      const jobs = Sanbashi.getJobs('rootfulroot', dockerfiles)
-      let chosenJob = await Sanbashi.chooseJobs(jobs, true)
-      expect(chosenJob[0]).to.have.property('dockerfile', dockerfiles[0])
-      expect(chosenJob[1]).to.have.property('dockerfile', dockerfiles[1])
-      expect(chosenJob).to.have.property('length', 2)
-    })
-
     it('returns the entry when only one exists', async () => {
       const dockerfiles = [Path.join('.', 'Nested', 'Dockerfile.web')]
       const jobs = Sanbashi.getJobs('rootfulroot', dockerfiles)
-      let chosenJob = await Sanbashi.chooseJobs(jobs, true)
+      let chosenJob = await Sanbashi.chooseJobs(jobs)
       expect(chosenJob[0]).to.have.property('dockerfile', dockerfiles[0])
       expect(chosenJob).to.have.property('length', 1)
     })
-
-    it('does not fetch the data recursively', async () => {
-      const dockerfiles = [Path.join('.', 'Nested', 'Dockerfile.web'), Path.join('.', 'Nested', 'Dockerfile.worker')]
-      const jobs = Sanbashi.getJobs('rootfulroot', dockerfiles)
-      let chosenJob = await Sanbashi.chooseJobs(jobs, false)
-      expect(chosenJob[0]).to.have.property('dockerfile', dockerfiles[0])
-      expect(chosenJob).to.have.property('length', 1)
-    })
-
     afterEach(() => {
       if (Inquirer.prompt.restore)
         Inquirer.prompt.restore()


### PR DESCRIPTION
Reverts heroku/heroku-container-registry#30
This is showing a bunch of side effects causing regressions. We need better tests in the CLI tool before we can move forward with this kind of refactoring.

See #36 and #35.