### PR TITLE
Turn the version into integers and handle invalid values

### DIFF
--- a/lib/sanbashi.js
+++ b/lib/sanbashi.js
@@ -115,9 +115,9 @@ Sanbashi.runImage = function (resource, command, port, verbose) {
 
 Sanbashi.version = function () {
   return Sanbashi
-      .cmd('docker', ['version', '-f', '{{.Client.Version}}'], {output: true})
-      .then(version => version.split(/\./))
-      .then(([major, minor]) => [major, minor]) // ensure exactly 2 components
+    .cmd('docker', ['version', '-f', '{{.Client.Version}}'], {output: true})
+    .then(version => version.split(/\./))
+    .then(([major, minor]) => [parseInt(major) || 0, parseInt(minor) || 0]) // ensure exactly 2 components
 }
 
 Sanbashi.cmd = function (cmd, args, options = {}) {

--- a/test/sanbashi.test.js
+++ b/test/sanbashi.test.js
@@ -115,11 +115,26 @@ describe('Sanbashi', () => {
     })
   })
   describe('.version', () => {
-    it('returns a major and a minor component', async () => {
+    it('returns a the major and minor version', async () => {
+      Sinon.stub(Sanbashi, 'cmd')
+        .withArgs('docker', ['version', '-f', '{{.Client.Version}}'], {output: true})
+        .resolves('18.02.0-ce-rc2')
+
       let version = await Sanbashi.version()
-      expect(version).to.have.property('length', 2)
-      expect(version[0]).to.not.be.an('undefined')
-      expect(version[1]).to.not.be.an('undefined')
+      expect(version).to.deep.equal([18, 2])
+    })
+
+    it('has an error', async () => {
+      Sinon.stub(Sanbashi, 'cmd')
+        .withArgs('docker', ['version', '-f', '{{.Client.Version}}'], {output: true})
+        .resolves('an error occured')
+
+      let version = await Sanbashi.version()
+      expect(version).to.deep.equal([0, 0])
+    })
+
+    afterEach(() => {
+      Sanbashi.cmd.restore() // Unwraps the spy
     })
   })
 })


### PR DESCRIPTION
Keeping the version as a string and then handling it as an integer can cause issues.
This also considers any error when getting the version as a version of 0., so we don't get NaN version numbers.