### PR TITLE
Password-stdin was introduced in 17.07, not 17.01

### DIFF
--- a/commands/login.js
+++ b/commands/login.js
@@ -31,7 +31,7 @@ async function login (context, heroku) {
 async function dockerLogin (registry, password, verbose) {
   let [major, minor] = await Sanbashi.version()
 
-  if (major > 17 || major === 17 && minor >= 1) {
+  if (major > 17 || major === 17 && minor >= 7) {
     return await dockerLoginStdin(registry, password, verbose)
   }
   return await dockerLoginArgv(registry, password, verbose)


### PR DESCRIPTION
See https://docs.docker.com/release-notes/docker-ce/#17070-ce-2017-08-29