### PR TITLE
Mention container:release after a push

### DIFF
--- a/commands/push.js
+++ b/commands/push.js
@@ -100,6 +100,7 @@ let push = async function (context, heroku) {
       }
       await Sanbashi.pushImage(job.resource)
     }
+    cli.log(`Your images have been successfully pushed. You can now release with them with the 'container:release' command.`)
   } catch (err) {
     cli.error(`Error: docker push exited with ${err}`, 1)
     return


### PR DESCRIPTION
Despite our communication, support is getting a fair number of support tickets. This log is intended to make sure customers know earlier.