### PR TITLE
Retrieve the image id to release from the registry

### DIFF
--- a/test/sanbashi.test.js
+++ b/test/sanbashi.test.js
@@ -137,19 +137,4 @@ describe('Sanbashi', () => {
       Sanbashi.cmd.restore() // Unwraps the spy
     })
   })
-
-  describe('.imageID', () => {
-    it('returns the image id for a tag', async () => {
-      Sinon.stub(Sanbashi, 'cmd')
-        .withArgs('docker', ['inspect', 'image:tag', '--format={{.Id}}'], {output: true})
-        .resolves('sha256:image_id\n')
-
-      let id = await Sanbashi.imageID('image:tag')
-      expect(id).to.equal('sha256:image_id')
-    })
-
-    afterEach(() => {
-      Sanbashi.cmd.restore() // Unwraps the spy
-    })
-  })
 })


### PR DESCRIPTION
So we don't need to have the image locally to release